### PR TITLE
adjust tool for xml importing only

### DIFF
--- a/src/DbLocalizationProvider.MigrationTool/MigrationToolOptions.cs
+++ b/src/DbLocalizationProvider.MigrationTool/MigrationToolOptions.cs
@@ -24,6 +24,9 @@ namespace DbLocalizationProvider.MigrationTool
         [Option('f', "fromDatabase", HelpText = "Export localization resources from database. `EPiServerDB` connection string name will be used.")]
         public bool ExportFromDatabase { get; set; }
 
+        [Option('x', "fromXmlOnly", HelpText = "Export localization resources from XML only.")]
+        public bool ExportFromXmlOnly { get; set; }
+
         [Option('j', "jsonFormat", HelpText = "Use JSON file format")]
         public bool Json { get; set; }
 

--- a/src/DbLocalizationProvider.MigrationTool/Program.cs
+++ b/src/DbLocalizationProvider.MigrationTool/Program.cs
@@ -34,27 +34,10 @@ namespace DbLocalizationProvider.MigrationTool
             if(!Directory.Exists(_settings.SourceDirectory))
                 throw new IOException($"Source directory `{_settings.SourceDirectory}` does not exist!");
 
-            Configuration config;
-
-            if(File.Exists(Path.Combine(_settings.SourceDirectory, "web.config")))
+            if(!_settings.ExportFromXmlOnly)
             {
-                Directory.SetCurrentDirectory(_settings.SourceDirectory);
-                config = GetWebConfig();
-                AppDomain.CurrentDomain.SetData("DataDirectory", Path.Combine(_settings.SourceDirectory, "App_Data"));
+                SetConnectionString();
             }
-            else if(File.Exists(Path.Combine(_settings.SourceDirectory, "app.config")))
-            {
-                Directory.SetCurrentDirectory(_settings.SourceDirectory);
-                config = ReadAppConnectionString();
-            }
-            else
-                throw new IOException($"Neither `web.config` nor `app.config` file not found in `{_settings.SourceDirectory}`!");
-
-            var connectionString = config.ConnectionStrings?.ConnectionStrings["EPiServerDB"]?.ConnectionString;
-            if(string.IsNullOrWhiteSpace(connectionString))
-                throw new ConfigurationErrorsException("Could not find EPiServer database connection.");
-
-            ConfigurationContext.Current.DbContextConnectionString = _settings.ConnectionString = connectionString;
 
             if(_settings.ExportResources)
             {
@@ -89,7 +72,7 @@ namespace DbLocalizationProvider.MigrationTool
                 }
             }
 
-            if(_settings.ImportResources)
+            if(!_settings.ExportFromXmlOnly && _settings.ImportResources)
             {
                 Console.WriteLine("Import started!");
 
@@ -109,6 +92,31 @@ namespace DbLocalizationProvider.MigrationTool
                 Console.ReadLine();
 
             return 0;
+        }
+
+        private static void SetConnectionString()
+        {
+            Configuration config = null;
+
+            if(File.Exists(Path.Combine(_settings.SourceDirectory, "web.config")))
+            {
+                Directory.SetCurrentDirectory(_settings.SourceDirectory);
+                config = GetWebConfig();
+                AppDomain.CurrentDomain.SetData("DataDirectory", Path.Combine(_settings.SourceDirectory, "App_Data"));
+            }
+            else if(File.Exists(Path.Combine(_settings.SourceDirectory, "app.config")))
+            {
+                Directory.SetCurrentDirectory(_settings.SourceDirectory);
+                config = ReadAppConnectionString();
+            }
+            else
+                throw new IOException($"Neither `web.config` nor `app.config` file not found in `{_settings.SourceDirectory}`!");
+
+            var connectionString = config?.ConnectionStrings?.ConnectionStrings["EPiServerDB"]?.ConnectionString;
+            if(string.IsNullOrWhiteSpace(connectionString))
+                throw new ConfigurationErrorsException("Could not find EPiServer database connection.");
+
+            ConfigurationContext.Current.DbContextConnectionString = _settings.ConnectionString = connectionString;
         }
 
         private static Configuration ReadAppConnectionString()

--- a/src/DbLocalizationProvider.MigrationTool/Properties/AssemblyInfo.cs
+++ b/src/DbLocalizationProvider.MigrationTool/Properties/AssemblyInfo.cs
@@ -5,8 +5,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("DbLocalizationProvider.MigrationTool")]
 [assembly: AssemblyDescription("Migration tool to move Xml resources to database or to extract from database. Pick direction whichever you need.")]
 [assembly: Guid("5227c16b-342c-4097-a9ed-295cdd164a61")]
-[assembly: AssemblyVersion("5.5.1.0")]
-[assembly: AssemblyFileVersion("5.5.1.0")]
-[assembly: AssemblyInformationalVersion("5.5.1")]
+[assembly: AssemblyVersion("5.6.0.0")]
+[assembly: AssemblyFileVersion("5.6.0.0")]
+[assembly: AssemblyInformationalVersion("5.6.0")]
 
 [assembly: InternalsVisibleTo("DbLocalizationProvider.MigrationTool.Tests, PublicKey=002400000480000094000000060200000024000052534131000400000100010061f7a9aa02c1a525f7e914f39ac8901fc05fbdbad295b3c3b17e168fb3e70818c453da4f6ccec386f92038352e2b040a393ea85e631a3da420d92ca1b39cd346a9d2bbe8ef5374d7eec997c7a2a2a93e7ce45a554efe561cadb6f10b86072b79d732729a8f3d43756e6f52c28543ed2ab2822e3dcc99ec25fe5f17bb02976fc0")]


### PR DESCRIPTION
Hi, @valdisiljuconoks ! Could you possibly look at that, please?

**Preconditions:**

- We have 3 stages on CI/CD. 
- We add new resources through xml during feature implementation. After delivery and testing on staging we export them to JSON and then import them on Epi Admin side in production.
- We use SSPI for our databases that are not available on CI/DI and we don't want to use SQL Server Authentication.

**Motivation:** 
Export resources from xml without db connection.


**Conclusion:** 
Adding this functionality allows us to call  import tool during build(via ps script for instance) and get resources artifact, that can be easily downloaded and imported by content maintainers.
