### PR TITLE
Allow duplicates

### DIFF
--- a/src/DbLocalizationProvider.MigrationTool/MigrationToolOptions.cs
+++ b/src/DbLocalizationProvider.MigrationTool/MigrationToolOptions.cs
@@ -33,6 +33,10 @@ namespace DbLocalizationProvider.MigrationTool
         [Option('i', "importResources", HelpText = "Import localization resources from SQL file into database")]
         public bool ImportResources { get; set; }
 
+        [Option('d', "ignoreDuplicateKey", HelpText = "Ignore duplicate keys (Take first found)")]
+        public bool IgnoreDuplicateKeys { get; set; }
+
+
         public string ConnectionString { get; set; }
 
         [Usage(ApplicationAlias = "DbLocalizationProvider.MigrationTool.exe")]

--- a/src/DbLocalizationProvider.MigrationTool/ResourceExtractor.cs
+++ b/src/DbLocalizationProvider.MigrationTool/ResourceExtractor.cs
@@ -74,7 +74,7 @@ namespace DbLocalizationProvider.MigrationTool
                 Console.WriteLine($"No resource files found in '{resourceFilesSourceDir}'");
             }
 
-            var fileProcessor = new ResourceFileProcessor();
+            var fileProcessor = new ResourceFileProcessor(settings.IgnoreDuplicateKeys);
 
             return fileProcessor.ParseFiles(resourceFiles);
         }

--- a/src/DbLocalizationProvider.MigrationTool/ResourceFileProcessor.cs
+++ b/src/DbLocalizationProvider.MigrationTool/ResourceFileProcessor.cs
@@ -32,7 +32,7 @@ namespace DbLocalizationProvider.MigrationTool
             {
                 var stream = File.OpenText(resourceFile);
                 var contentXml = XDocument.Load(stream);
-                var resources = _parser.ReadXml(contentXml);
+                var resources = _parser.ReadXml(contentXml, _ignoreDuplicateKeys);
 
                 result = _mergeTool.Merge(result, resources, _ignoreDuplicateKeys).ToList();
             }

--- a/src/DbLocalizationProvider.MigrationTool/ResourceFileProcessor.cs
+++ b/src/DbLocalizationProvider.MigrationTool/ResourceFileProcessor.cs
@@ -10,11 +10,13 @@ namespace DbLocalizationProvider.MigrationTool
     {
         private readonly XmlDocumentParser _parser;
         private readonly ResourceListMerger _mergeTool;
+        private readonly bool _ignoreDuplicateKeys;
 
-        public ResourceFileProcessor()
+        public ResourceFileProcessor(bool ignoreDuplicateKeys)
         {
             _parser = new XmlDocumentParser();
             _mergeTool = new ResourceListMerger();
+            _ignoreDuplicateKeys = ignoreDuplicateKeys;
         }
 
         public ICollection<LocalizationResource> ParseFiles(string[] resourceFiles)
@@ -32,7 +34,7 @@ namespace DbLocalizationProvider.MigrationTool
                 var contentXml = XDocument.Load(stream);
                 var resources = _parser.ReadXml(contentXml);
 
-                result = _mergeTool.Merge(result, resources).ToList();
+                result = _mergeTool.Merge(result, resources, _ignoreDuplicateKeys).ToList();
             }
 
             return result;

--- a/src/DbLocalizationProvider.MigrationTool/ResourceListMerger.cs
+++ b/src/DbLocalizationProvider.MigrationTool/ResourceListMerger.cs
@@ -40,7 +40,7 @@ namespace DbLocalizationProvider.MigrationTool
                 if (result.Any(r => r.ResourceKey == resourceItem.ResourceKey))
                 {
                     // resource exists in target list - need to merge translations
-                    var matchedResource = result.First(r => r.ResourceKey == resourceItem.ResourceKey);
+                    var matchedResource = result.First(r => r.ResourceKey.ToLower() == resourceItem.ResourceKey.ToLower());
                     foreach (var resourceTranslation in resourceItem.Translations)
                     {
                         if (matchedResource.Translations.Any(t => t.Language == resourceTranslation.Language))

--- a/src/DbLocalizationProvider.MigrationTool/ResourceListMerger.cs
+++ b/src/DbLocalizationProvider.MigrationTool/ResourceListMerger.cs
@@ -8,6 +8,11 @@ namespace DbLocalizationProvider.MigrationTool
     {
         public ICollection<LocalizationResource> Merge(ICollection<LocalizationResource> list1, ICollection<LocalizationResource> list2)
         {
+            return Merge(list1, list2, false);
+        }
+
+        public ICollection<LocalizationResource> Merge(ICollection<LocalizationResource> list1, ICollection<LocalizationResource> list2, bool ignoreDuplicateKeys)
+        {
             if (list1 == null)
             {
                 throw new ArgumentNullException(nameof(list1));
@@ -40,10 +45,16 @@ namespace DbLocalizationProvider.MigrationTool
                     {
                         if (matchedResource.Translations.Any(t => t.Language == resourceTranslation.Language))
                         {
-                            // there is already a translation in this culture - we can't resolve this conflict. blowing up
-                            throw new NotSupportedException($"There are duplicate translations for resource '{matchedResource.ResourceKey}' in culture '{resourceTranslation.Language}'");
+                            if (ignoreDuplicateKeys)
+                            {
+                                Console.WriteLine($"{matchedResource.ResourceKey} Additional resource with same key found, Ignored");
+                            }
+                            else
+                            {
+                                // there is already a translation in this culture - we can't resolve this conflict. blowing up
+                                throw new NotSupportedException($"There are duplicate translations for resource '{matchedResource.ResourceKey}' in culture '{resourceTranslation.Language}'. Use -d to ignore duplicates");
+                            }
                         }
-
                         matchedResource.Translations.Add(resourceTranslation);
                     }
                 }

--- a/src/DbLocalizationProvider.MigrationTool/ResourceListMerger.cs
+++ b/src/DbLocalizationProvider.MigrationTool/ResourceListMerger.cs
@@ -55,7 +55,11 @@ namespace DbLocalizationProvider.MigrationTool
                                 throw new NotSupportedException($"There are duplicate translations for resource '{matchedResource.ResourceKey}' in culture '{resourceTranslation.Language}'. Use -d to ignore duplicates");
                             }
                         }
-                        matchedResource.Translations.Add(resourceTranslation);
+                        else
+                        {
+                            matchedResource.Translations.Add(resourceTranslation);
+                        }
+                        
                     }
                 }
                 else

--- a/src/DbLocalizationProvider.MigrationTool/XmlDocumentParser.cs
+++ b/src/DbLocalizationProvider.MigrationTool/XmlDocumentParser.cs
@@ -63,7 +63,7 @@ namespace DbLocalizationProvider.MigrationTool
                         continue;
                     }
 
-                    var existingResource = result.FirstOrDefault(r => r.ResourceKey == resourceKey.ToLower());
+                    var existingResource = result.FirstOrDefault(r => r.ResourceKey.ToLower() == resourceKey.ToLower());
 
                     if (existingResource != null)
                     {
@@ -89,7 +89,7 @@ namespace DbLocalizationProvider.MigrationTool
                     {
                         var resourceEntry = new LocalizationResource
                                             {
-                                                ResourceKey = resourceKey.ToLower(),
+                                                ResourceKey = resourceKey,
                                                 ModificationDate = DateTime.Now,
                                                 Author = "migration-tool"
                                             };

--- a/src/DbLocalizationProvider.MigrationTool/XmlDocumentParser.cs
+++ b/src/DbLocalizationProvider.MigrationTool/XmlDocumentParser.cs
@@ -63,7 +63,7 @@ namespace DbLocalizationProvider.MigrationTool
                         continue;
                     }
 
-                    var existingResource = result.FirstOrDefault(r => r.ResourceKey == resourceKey);
+                    var existingResource = result.FirstOrDefault(r => r.ResourceKey == resourceKey.ToLower());
 
                     if (existingResource != null)
                     {
@@ -89,7 +89,7 @@ namespace DbLocalizationProvider.MigrationTool
                     {
                         var resourceEntry = new LocalizationResource
                                             {
-                                                ResourceKey = resourceKey,
+                                                ResourceKey = resourceKey.ToLower(),
                                                 ModificationDate = DateTime.Now,
                                                 Author = "migration-tool"
                                             };

--- a/src/DbLocalizationProvider.MigrationTool/XmlDocumentParser.cs
+++ b/src/DbLocalizationProvider.MigrationTool/XmlDocumentParser.cs
@@ -9,6 +9,11 @@ namespace DbLocalizationProvider.MigrationTool
     {
         public ICollection<LocalizationResource> ReadXml(XDocument xmlDocument)
         {
+            return ReadXml(xmlDocument, false);
+        }
+
+        public ICollection<LocalizationResource> ReadXml(XDocument xmlDocument, bool ignoreDuplicateKeys)
+        {
             if (xmlDocument == null)
             {
                 throw new ArgumentNullException(nameof(xmlDocument));
@@ -21,7 +26,7 @@ namespace DbLocalizationProvider.MigrationTool
             foreach (var languageElement in allLanguageElements.Elements("language"))
             {
                 var cultureId = languageElement.Attribute("id");
-                ParseResource(languageElement.Elements(), cultureId.Value, result, string.Empty);
+                ParseResource(languageElement.Elements(), cultureId.Value, result, string.Empty, ignoreDuplicateKeys);
             }
 
             return result;
@@ -30,7 +35,8 @@ namespace DbLocalizationProvider.MigrationTool
         private static void ParseResource(IEnumerable<XElement> resourceElements,
                                           string cultureName,
                                           ICollection<LocalizationResource> result,
-                                          string keyPrefix)
+                                          string keyPrefix,
+                                          bool ignoreDuplicateKeys)
         {
             foreach (var element in resourceElements)
             {
@@ -46,7 +52,7 @@ namespace DbLocalizationProvider.MigrationTool
 
                 if (element.HasElements)
                 {
-                    ParseResource(element.Elements(), cultureName, result, resourceKey);
+                    ParseResource(element.Elements(), cultureName, result, resourceKey, ignoreDuplicateKeys);
                 }
                 else
                 {
@@ -65,14 +71,19 @@ namespace DbLocalizationProvider.MigrationTool
 
                         if (existingTranslation != null)
                         {
-                            throw new NotSupportedException($"Found duplicate translations for resource with key: {resourceKey} for culture: {cultureName}");
+                            if (!ignoreDuplicateKeys)
+                            { 
+                                throw new NotSupportedException($"Found duplicate translations for resource with key: {resourceKey} for culture: {cultureName}");
+                            }
                         }
-
-                        existingResource.Translations.Add(new LocalizationResourceTranslation
-                                                          {
-                                                              Language = cultureName,
-                                                              Value = resourceTranslation
-                                                          });
+                        else
+                        { 
+                            existingResource.Translations.Add(new LocalizationResourceTranslation
+                                                              {
+                                                                  Language = cultureName,
+                                                                  Value = resourceTranslation
+                                                              });
+                        }
                     }
                     else
                     {

--- a/tests/DbLocalizationProvider.MigrationTool.Tests/ResourceListMergerTests.cs
+++ b/tests/DbLocalizationProvider.MigrationTool.Tests/ResourceListMergerTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Xunit;
@@ -121,6 +122,81 @@ namespace DbLocalizationProvider.MigrationTool.Tests
                         };
 
             var result = merger.Merge(list1, list2);
+
+            Assert.NotEmpty(result);
+            Assert.Single(result);
+
+            var finalResource = result.First();
+
+            Assert.Equal(2, finalResource.Translations.Count);
+        }
+
+        [Fact]
+        public void BothListsFilledWithTranslations_SameKeys_Duplicate_Translation_Throws()
+        {
+            var merger = new ResourceListMerger();
+
+            var resource1English = new LocalizationResource("key1");
+            resource1English.Translations.Add(new LocalizationResourceTranslation
+            {
+                Language = "en",
+                Value = "hello"
+            });
+
+            var resource1Norsk = new LocalizationResource("key1");
+            resource1Norsk.Translations.Add(new LocalizationResourceTranslation
+            {
+                Language = "no",
+                Value = "hei"
+            });
+            
+            var list1 = new List<LocalizationResource>
+                        {
+                            resource1English
+                        };
+
+            var list2 = new List<LocalizationResource>
+                        {
+                            resource1Norsk,
+                            //Duplicate translation that makes the merger throw
+                            resource1Norsk
+                        };
+
+            Assert.Throws(typeof(NotSupportedException), () => merger.Merge(list1, list2));
+        }
+
+        [Fact]
+        public void BothListsFilledWithTranslations_SameKeys_Duplicate_Translation_With_AllowDuplicateKeys_Option()
+        {
+            var merger = new ResourceListMerger();
+
+            var resource1English = new LocalizationResource("key1");
+            resource1English.Translations.Add(new LocalizationResourceTranslation
+            {
+                Language = "en",
+                Value = "hello"
+            });
+
+            var resource1Norsk = new LocalizationResource("key1");
+            resource1Norsk.Translations.Add(new LocalizationResourceTranslation
+            {
+                Language = "no",
+                Value = "hei"
+            });
+
+            var list1 = new List<LocalizationResource>
+                        {
+                            resource1English
+                        };
+
+            var list2 = new List<LocalizationResource>
+                        {
+                            resource1Norsk,
+                            //Duplicate translation that makes the merger throw if -d option is not set.
+                            resource1Norsk
+                        };
+
+            var result = merger.Merge(list1, list2, true);
 
             Assert.NotEmpty(result);
             Assert.Single(result);

--- a/tests/DbLocalizationProvider.MigrationTool.Tests/XmlReaderMultipleLanguageTests.cs
+++ b/tests/DbLocalizationProvider.MigrationTool.Tests/XmlReaderMultipleLanguageTests.cs
@@ -56,5 +56,33 @@ namespace DbLocalizationProvider.MigrationTool.Tests
 
             Assert.Throws<NotSupportedException>(() => parser.ReadXml(doc).ToList());
         }
+
+        [Fact]
+        public void SingleResourceDuplicateLanguages_ExceptionNotThrownWithIgnoreDuplicateKeysOption()
+        {
+            var xmlSample = @"<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes""?>
+            <languages>
+              <language name=""English"" id=""en"">
+                <displayoption>This is display option</displayoption>
+              </language>
+              <language name=""English"" id=""en"">
+                <displayoption>Whatever!</displayoption>
+              </language>
+            </languages>";
+
+            var parser = new XmlDocumentParser();
+            var doc = XDocument.Parse(xmlSample);
+
+            var resource = parser.ReadXml(doc, true).ToList();
+
+            var firstResource = resource.First();
+            Assert.Equal("/displayoption", firstResource.ResourceKey);
+
+            Assert.Equal(1, firstResource.Translations.Count);
+
+            var englishTranslation = firstResource.Translations.First(t => t.Language == "en");
+            Assert.Equal("en", englishTranslation.Language);
+            Assert.Equal("This is display option", englishTranslation.Value);
+        }
     }
 }


### PR DESCRIPTION
Patch to allow for export even if there are duplicate resources with the same key.
New -d option added to allow this 