### PR TITLE
feat: enable inner caching replacement for DbLocalization Optimizely registration with new DbLocalizationConfigurationContext

### DIFF
--- a/src/DbLocalizationProvider.EPiServer/DbLocalizationConfigurationContext.cs
+++ b/src/DbLocalizationProvider.EPiServer/DbLocalizationConfigurationContext.cs
@@ -1,0 +1,14 @@
+using DbLocalizationProvider.Cache;
+
+namespace DbLocalizationProvider.EPiServer;
+
+/// <summary>
+/// Configuration context for DbLocalizationProvider.EPiServer.
+/// </summary>
+public class DbLocalizationConfigurationContext
+{
+    /// <summary>
+    /// Allows to override internal cache implementation, if problems with default EPiServer implementation arise.
+    /// </summary>
+    public ICache InnerCache { get; set; } = new EPiServerCache();
+}

--- a/src/DbLocalizationProvider.EPiServer/IServiceCollectionExtensions.cs
+++ b/src/DbLocalizationProvider.EPiServer/IServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Valdis Iljuconoks. All rights reserved.
 // Licensed under Apache-2.0. See the LICENSE file in the project root for more information
 
+using System;
 using System.Globalization;
 using System.Linq;
 using DbLocalizationProvider.AspNetCore;
@@ -23,10 +24,15 @@ public static class IServiceCollectionExtensions
     /// Adds Optimizely support for DbLocalizationProvider.
     /// </summary>
     /// <param name="builder">Provider builder interface (to capture context and service collection).</param>
+    /// <param name="setup">If required, modify configurations using the <see cref="DbLocalizationConfigurationContext"/></param>
     /// <returns>Service collection to support fluent API.</returns>
-    public static IDbLocalizationProviderBuilder AddOptimizely(this IDbLocalizationProviderBuilder builder)
+    public static IDbLocalizationProviderBuilder AddOptimizely(this IDbLocalizationProviderBuilder builder, Action<DbLocalizationConfigurationContext>? setup = null)
     {
-        builder.Context._baseCacheManager.SetInnerManager(new EPiServerCache());
+        var configContext = new DbLocalizationConfigurationContext();
+
+        setup?.Invoke(configContext);
+
+        builder.Context._baseCacheManager.SetInnerManager(configContext.InnerCache);
 
         builder.Services.AddTransient<IResourceTypeScanner, LocalizedCategoryScanner>();
 


### PR DESCRIPTION
**When using localization manager together with multi-instance Optimizely application, we are experiencing severe performance problems during bulk clear cache operations.**

As currently `EPiServerCache` is enforced during `.AddOptimizely(...)` configuration, eventually:
1.In the namespace `DbLocalizationProvider.AspNetCore.Cache`, `ClearCacheHandler.Execute`: calls cache.Remove(...) from a loop for each cache key.
2. In the namespace `DbLocalizationProvider.Cache`, `_inner.Remove(k)` which is triggering the EPiServerCache.
3. In the namespace `DbLocalizationProvider.EPiServer`, `CacheManager.Remove(key)` is called.
4. The CacheManager is synchronizing resources using `IEventRegistry _eventService`. The method itself is marked as the one, which shouldn't be called from loops and rather dependency tree should be built with master-object invalidation.

EPiServer.CacheManager:
```
    /// <summary>
    /// Removes item from the local cache and other remote cache listeners.
    /// </summary>
    /// <param name="key">The cache key to remove</param>
    /// <remarks>This method will automatically forward updates
    /// to other machines. Do not use this method in loops, since every call could result
    /// in a web service call to multiple machines. The recommended pattern when you have
    /// multiple items that needs to be removed is to have a master dependency item that can
    /// be removed instead, to trigger all items to be removed.</remarks>
    public static void Remove(string key) => CacheManager.CacheImplementation.Remove(key);
```

As the solution to implement proper bulk cache invalidation might be more complicated in the current implementation (as building new structures will be required since Optimizely cache doesn't offer simple out-of-the-box bulk cache operations), **PR enables replacement of default `EPiServerCache` with any `ICache` implementation, where handling of synchronization events can be done differently.**